### PR TITLE
Make sure the document ID includes `audioPath` as an additional unique identifier.

### DIFF
--- a/lib/models/attempt_model.dart
+++ b/lib/models/attempt_model.dart
@@ -29,7 +29,7 @@ class AttemptModel {
     required this.score,
     required this.devicePlatform,
     required this.deviceOS,
-  }) : id = id ?? FirestoreUtils.generateDeterministicAttemptId(classId, userId, wordId);
+  }) : id = id ?? FirestoreUtils.generateDeterministicAttemptId(classId, userId, wordId, audioPath);
 
   // Convert AttemptModel instance to JSON for Firestore storage.
   Map<String, dynamic> toJson() {

--- a/lib/utils/firestore_utils.dart
+++ b/lib/utils/firestore_utils.dart
@@ -5,12 +5,12 @@ import 'package:crypto/crypto.dart';
 /// Small utility helpers used by Firestore-backed models.
 class FirestoreUtils {
   
-  /// Generate a deterministic id from `classId`, `userId`, and `wordId`.
+  /// Generate a deterministic id from `classId`, `userId`, `wordId`, and `audioPath`.
   ///
-  /// This uses SHA-256 over the string `<classId>|<userId>|<wordId>` and returns the
+  /// This uses SHA-256 over the string `<classId>|<userId>|<wordId>|<audioPath>|` and returns the
   /// hex digest. The result is stable across runs for the same inputs.
-  static String generateDeterministicAttemptId(String classId, String userId, String wordId) {
-    final input = '$classId|$userId|$wordId';
+  static String generateDeterministicAttemptId(String classId, String userId, String wordId, String audioPath) {
+    final input = '$classId|$userId|$wordId|$audioPath';
     final bytes = utf8.encode(input);
     final digest = sha256.convert(bytes);
     return digest.toString();

--- a/test/unit/attempt_model_test.dart
+++ b/test/unit/attempt_model_test.dart
@@ -20,7 +20,7 @@ void main() {
         deviceOS: '11',
       );
 
-      final expected = FirestoreUtils.generateDeterministicAttemptId('class123', 'user456', 'attempt');
+      final expected = FirestoreUtils.generateDeterministicAttemptId('class123', 'user456', 'attempt', '/path/to/user456_attempt_1234567890.aac');
       expect(m.id, equals(expected));
     });
 

--- a/test/unit/attempt_repository_test.dart
+++ b/test/unit/attempt_repository_test.dart
@@ -81,6 +81,80 @@ void main() {
       expect(ids.contains(attempt3.id), isFalse);
     });
 
+    test('fetchAttemptsByUser with two aac attempts for same user and word returns both', () async {
+      final target1 = AttemptModel(
+        classId: 'classX',
+        userId: 'user-123',
+        wordId: 'target-word',
+        speechToTextTranscript: 'target transcript one',
+        audioCodec: AudioCodec.aac,
+        audioPath: '/audio/target1.aac',
+        durationMS: 1200,
+        confidence: 0.77,
+        score: 0.88,
+        devicePlatform: 'android',
+        deviceOS: '12',
+      );
+      final target2 = AttemptModel(
+        classId: 'classX',
+        userId: 'user-123',
+        wordId: 'target-word',
+        speechToTextTranscript: 'target transcript two',
+        audioCodec: AudioCodec.aac,
+        audioPath: '/audio/target2.aac',
+        durationMS: 1250,
+        confidence: 0.80,
+        score: 0.90,
+        devicePlatform: 'android',
+        deviceOS: '12',
+      );
+      final sameWordDifferentCodec = AttemptModel(
+        classId: 'classX',
+        userId: 'user-123',
+        wordId: 'target-word',
+        speechToTextTranscript: 'other codec transcript',
+        audioCodec: AudioCodec.wav,
+        audioPath: '/audio/target.wav',
+        durationMS: 1100,
+        confidence: 0.66,
+        score: 0.70,
+        devicePlatform: 'android',
+        deviceOS: '12',
+      );
+      final otherUserSameCombo = AttemptModel(
+        classId: 'classX',
+        userId: 'user-456',
+        wordId: 'target-word',
+        speechToTextTranscript: 'other user transcript',
+        audioCodec: AudioCodec.aac,
+        audioPath: '/audio/otheruser.aac',
+        durationMS: 1300,
+        confidence: 0.8,
+        score: 0.85,
+        devicePlatform: 'android',
+        deviceOS: '11',
+      );
+
+      await repo.upsertAttempt(target1);
+      await repo.upsertAttempt(target2);
+      await repo.upsertAttempt(sameWordDifferentCodec);
+      await repo.upsertAttempt(otherUserSameCombo);
+
+      final attempts = await repo.fetchAttemptsByUser(
+        'user-123',
+        wordId: 'target-word',
+        audioCodec: AudioCodec.aac,
+      );
+
+      expect(attempts.length, equals(2));
+      final ids = attempts.map((a) => a.id).toSet();
+      expect(ids.contains(target1.id), isTrue);
+      expect(ids.contains(target2.id), isTrue);
+      expect(ids.contains(sameWordDifferentCodec.id), isFalse);
+      expect(ids.contains(otherUserSameCombo.id), isFalse);
+    });
+
+
     test('upsertAttempt updates existing document with new values', () async {
       final original = AttemptModel(
         classId: 'upsertClass',


### PR DESCRIPTION
If we only include `classId`, `userId` and `wordId` as the SHA-256 hash then if the user tried the same word over it would just update the existing document. To be able to make distinct recording attempts we need another identifer `audioPath` that provides uniqueness.
