### PR TITLE
Prevent `REPLAY` when the student passes the word.

### DIFF
--- a/lib/screens/student/student_word_feedback_screen.dart
+++ b/lib/screens/student/student_word_feedback_screen.dart
@@ -241,12 +241,6 @@ class _StudentWordFeedbackPageState extends State<StudentWordFeedbackPage> {
               const SizedBox(height: 20),
               // Always show the next button even if the user scores low.
               _buildDashboardNextButton(),
-              // (_currentScore >= _passingThresholdStars)
-              //     ? Column(children: [
-              //           _buildDashboardNextButton(),
-              //         ],
-              //       )
-              //     : Container(),
             ],
           ),
         ),
@@ -493,23 +487,39 @@ class _StudentWordFeedbackPageState extends State<StudentWordFeedbackPage> {
   // }
 
   Widget _buildRetryButton() {
-    return GestureDetector(
-      onTap: _handleRetry,
-      child: Container(
-        height: 44,
-        width: 136,
-        decoration: BoxDecoration(
-          color: AppColors.buttonPrimaryOrange,
-          borderRadius: BorderRadius.circular(1000),
-        ),
-        child: const Center(
-          child: Text(
-            'RETRY',
-            style: AppStyles.buttonText,
+    return
+    (_currentScore >= _passingThresholdStars)
+      ? Container(
+          height: 44,
+          width: 136,
+          decoration: BoxDecoration(
+            color: AppColors.bgPrimaryGray,
+            borderRadius: BorderRadius.circular(1000),
+          ),
+          child: const Center(
+            child: Text(
+              'RETRY',
+              style: AppStyles.buttonText,
+            ),
+          ),
+        )
+      : GestureDetector(
+        onTap: _handleRetry,
+        child: Container(
+          height: 44,
+          width: 136,
+          decoration: BoxDecoration(
+            color: AppColors.buttonPrimaryOrange,
+            borderRadius: BorderRadius.circular(1000),
+          ),
+          child: const Center(
+            child: Text(
+              'RETRY',
+              style: AppStyles.buttonText,
+            ),
           ),
         ),
-      ),
-    );
+      );
   }
 
   Widget _buildDashboardNextButton() {


### PR DESCRIPTION
As part of the student flow, we want to remove the `REPLAY` button whenever the student passes the word. Disabling the `REPLAY` button is rather than hiding the button was the better option to avoid changing layout of where the `NEXT` button resides.

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/d656228a-05f0-412d-aa3d-3bb9cbd672cb" />

