### PR TITLE
Prevent instructor accounts from accessing the student word practice flow.

### DIFF
--- a/lib/screens/student/student_login_screen.dart
+++ b/lib/screens/student/student_login_screen.dart
@@ -8,7 +8,7 @@ import '../../services/class_repository.dart';
 import '../../services/user_repository.dart';
 import '../../utils/app_colors.dart';
 import '../../utils/app_styles.dart';
-// import '../../utils/enums.dart';
+import '../../utils/enums.dart';
 import '../../utils/validators.dart';
 
 class StudentLoginPage extends StatefulWidget {
@@ -45,7 +45,7 @@ class _StudentLoginPageState extends State<StudentLoginPage> {
               context.read<CurrentUserModel>().classSection = classModels.first;
             }
 
-            navigateToDashboard();
+            checkUserRoleAccess();
           });
         } else {
           debugPrint('No persisted user found.');
@@ -70,6 +70,44 @@ class _StudentLoginPageState extends State<StudentLoginPage> {
         backgroundColor: bgColor ?? AppColors.bgPrimaryDarkGrey,
       ),
     );
+  }
+
+  void checkUserRoleAccess() {
+    // Perform an additional check to ensure that this is not a
+    // student user logged in. We only want students.
+    switch (userModel!.role) {
+      case UserRole.teacher:
+        debugPrint('Practicing words can only be accessed by students!');
+        
+        _showSnackBar(
+          message: 'Practicing words can only be accessed by students!',
+          duration: const Duration(seconds: 2),
+          bgColor: AppColors.bgPrimaryRed,
+        );
+
+        Future.delayed(const Duration(seconds: 3)).then((_) {
+          if (!mounted) return;
+          setState(() {
+            // Traverse back to the reader selection screen
+            Navigator.pushNamedAndRemoveUntil(
+              context,
+              '/reader-selection',
+              (Route<dynamic> route) => false,
+            );
+
+            isVerifyingExistingLoginSession = false;
+          });
+        });
+
+        break;
+      case UserRole.student:
+        navigateToDashboard();
+        break;
+    }
+
+    // Exit early to prevent navigating to the student dashboard
+    // Important for teacher role case above
+    return;
   }
 
   void navigateToDashboard() async {

--- a/lib/screens/student/student_passcode_verification_screen.dart
+++ b/lib/screens/student/student_passcode_verification_screen.dart
@@ -7,6 +7,7 @@ import 'package:readright/services/user_repository.dart';
 
 import '../../utils/app_colors.dart';
 import '../../utils/app_styles.dart';
+import '../../utils/enums.dart';
 
 class StudentPasscodeVerificationPage extends StatefulWidget {
   final String? username;
@@ -90,6 +91,36 @@ class _StudentPasscodeVerificationPageState
       );
       return;
     } 
+
+    // At this point, logging in as a teacher should be unsuccessful
+    // do to invalid username/password combination.
+    // We're performing this extra check to ensure the user role is
+    // correct should the teacher be able to log in successfully.
+    // Check to ensure the user has the correct role (student).
+    // Redirect if not a student to the reader selection screen.
+    // ignore: use_build_context_synchronously
+    final currentUser = context.read<CurrentUserModel>().user;
+    if (currentUser == null || currentUser.role != UserRole.student) {
+      _showSnackBar(
+        message: 'Access denied. This account is not registered as a student.',
+        duration: const Duration(seconds: 2),
+        bgColor: AppColors.bgPrimaryRed,
+      );
+
+      Future.delayed(const Duration(seconds: 3)).then((_) {
+          if (!mounted) return;
+          setState(() {
+            // Traverse back to the reader selection screen
+            Navigator.pushNamedAndRemoveUntil(
+              context,
+              '/reader-selection',
+              (Route<dynamic> route) => false,
+            );
+          });
+        });
+      
+      return;
+    }
 
     await Future.delayed(const Duration(seconds: 3));
 


### PR DESCRIPTION
To avoid the class average numbers from being affected by the teacher, we're preventing the teacher from logging in to this screen. The teacher could alternatively create a student account for themselves to test further if needed.

Display a SnackBar message to the teacher should they use persistent login and bounce them back to the user selection screen.

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/19ed5ab7-dc26-4275-b0c6-d261c6eadddf" />


