### PR TITLE
Try to amplify the sound for the audio practice word playback on the student word details screen.

### DIFF
--- a/lib/screens/teacher/class/class_student_details_screen.dart
+++ b/lib/screens/teacher/class/class_student_details_screen.dart
@@ -169,6 +169,22 @@ class _ClassStudentDetailsState extends State<ClassStudentDetails> {
     debugPrint("url: $url");
 
     try {
+      // TODO: This seemed to not work at max volume = 1.0 like we do with the
+      // PCM amplification in the 'lib/audio/stream/pcm_player.dart' file.
+      // Consider in the future to convert AAC to PCM for amplification if needed.
+      //
+      // Try to amplify playback (may be platform-limited). If setVolume isn't supported it will be ignored.
+      try {
+        // Ensure volume is within the allowed range [0.0, 1.0].
+        // If you intended to amplify above 1.0, clamp to the max supported value.
+        final double desiredVolume = 2.0;
+        final double safeVolume = (desiredVolume.clamp(0.0, 1.0)) as double;
+        await _player.setVolume(safeVolume);
+        debugPrint('ClassStudentDetails: Requested amplified volume: $desiredVolume, applied: $safeVolume');
+      } catch (volErr) {
+        debugPrint('ClassStudentDetails: Could not set FlutterSoundPlayer volume: $volErr');
+      }
+
       await _player.startPlayer(
         fromURI: url,
         codec: Codec.aacMP4,


### PR DESCRIPTION
Using the FlutterSoundPlayer built-in volume to increase the gain to max 1.0 value didn't seem to help.

On the left, I tried setting the FlutterSoundPlayer by increasing the volume but that didn't seem to help with max set at 1.0. On the right, I used software to manipulate the PCM bytes to amplify the sound for playback to the student on the feedback screen. This does work. I don't think we should spend anymore time on this for now because what you've done works. We could convert the AAC file to PCM and then run it through the PCM gain code on the right and that should work but that's a lot of extra work.

<img width="3360" height="1390" alt="image" src="https://github.com/user-attachments/assets/4dc777b8-75ad-48c9-81f0-2712e3c70ac3" />

