### PR TITLE
Implementation of Profile Screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
 import 'package:readright/models/current_user_model.dart';
+import 'package:readright/screens/profile_screen.dart';
 import 'package:readright/services/attempt_repository.dart';
 import 'package:readright/services/class_repository.dart';
 import 'package:readright/services/student_progress_repository.dart';
@@ -236,6 +237,7 @@ class ReadRightApp extends StatelessWidget {
         '/teacher-dashboard': (context) => const TeacherDashboardPage(),
         '/teacher-word-dashboard': (context) =>  TeacherWordDashboardPage(),
         '/class-dashboard': (context) => const ClassDashboard(),
+        '/profile-settings': (context) => const ProfilePage(),
 //        '/class-student-details': (context) => const ClassStudentDetails(),
       },
       debugShowCheckedModeBanner: false,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:readright/models/current_user_model.dart';
+import 'package:provider/provider.dart';
+import '../models/user_model.dart';
+import '../utils/app_colors.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+
+// Stateful for future releases to allow changes to password, email, etc.
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  UserModel? _currentUser;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Fetch current user
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        _currentUser = context.read<CurrentUserModel>().user;
+
+        if (_currentUser != null) {
+          debugPrint(
+            'Found user session for ${_currentUser?.username}',
+          );
+        } else {
+          debugPrint('No existing user session found.');
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Profile"),
+        backgroundColor: AppColors.bgPrimaryLightBlue,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 20),
+            Text(
+              "Username: ${_currentUser!.username}",
+              style: const TextStyle(fontSize: 18),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              "Name: ${_currentUser!.username}",
+              style: const TextStyle(fontSize: 18),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              "Email: ${_currentUser!.email}",
+              style: const TextStyle(fontSize: 18),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.logout),
+              label: const Text(
+                "Log Out",
+                style: const TextStyle(fontSize: 18),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.bgPrimaryRed,
+                foregroundColor: Colors.white,
+              ),
+              onPressed: () async {
+                try {
+                  context.read<CurrentUserModel>().logOut();
+                  debugPrint('Successfully called logOut');
+                } catch (e, st) {
+                  debugPrint('Failed to log out: $e\n$st');
+                }
+
+
+                // Clear stack and kick back to user selection screen
+                Navigator.pushNamedAndRemoveUntil(
+                  context,
+                  '/reader-selection',
+                      (route) => false,
+                );
+              },
+            ),
+            const Spacer(),
+            InkWell(
+              child: const Text(
+                "About",
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.blue,
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+              onTap: () async {
+                debugPrint("Attempting to open link");
+                final Uri url = Uri.parse('https://github.com/ztraboo/readright');
+                await launchUrl(url, mode: LaunchMode.externalApplication);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/student/student_word_dashboard_screen.dart
+++ b/lib/screens/student/student_word_dashboard_screen.dart
@@ -194,9 +194,25 @@ class _StudentWordDashboardPageState extends State<StudentWordDashboardPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 90),
-                const Text(
-                  'Dashboard',
-                  style: AppStyles.headerText,
+                Row(
+                  children: [
+                    const Text(
+                      'Dashboard',
+                      style: AppStyles.headerText,
+                    ),
+                    const Spacer(),
+                    IconButton(
+                        icon: const Icon(Icons.account_circle, color: AppColors.buttonPrimaryGray),
+                        iconSize: 36, 
+                        onPressed: () {
+                          debugPrint("Icon Pressed");
+                          Navigator.pushNamed(
+                            context,
+                            '/profile-settings',
+                          );
+                        }
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 22),
                 Container(

--- a/lib/screens/teacher/class/class_student_details_screen.dart
+++ b/lib/screens/teacher/class/class_student_details_screen.dart
@@ -292,6 +292,18 @@ class _ClassStudentDetailsState extends State<ClassStudentDetails> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Student Details',style: TextStyle(fontWeight: FontWeight.bold)),
+          actions: [
+            IconButton(
+                icon: const Icon(Icons.account_circle, color: AppColors.buttonPrimaryGray),
+                onPressed: () {
+                  debugPrint("Icon Pressed");
+                  Navigator.pushNamed(
+                    context,
+                    '/profile-settings',
+                  );
+                }
+            ),
+          ],
           bottom: const TabBar(
             tabs: [
               Tab(icon: Icon(Icons.info_outline,color: AppColors.buttonPrimaryGray), text: 'Student Details'),

--- a/lib/screens/teacher/teacher_dashboard_screen.dart
+++ b/lib/screens/teacher/teacher_dashboard_screen.dart
@@ -50,7 +50,7 @@ class _TeacherDashboardPageState extends State<TeacherDashboardPage> {
           );
         } else {
           debugPrint('TeacherDashboardPage: No existing user session found.');
-        } 
+        }
 
         _classSection = context.read<CurrentUserModel>().classSection;
 
@@ -191,6 +191,18 @@ class _TeacherDashboardPageState extends State<TeacherDashboardPage> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Teacher Dashboard',style: TextStyle(fontWeight: FontWeight.bold)),
+          actions: [
+            IconButton(
+                icon: const Icon(Icons.account_circle, color: AppColors.buttonPrimaryGray),
+                onPressed: () {
+                  debugPrint("Icon Pressed");
+                  Navigator.pushNamed(
+                    context,
+                    '/profile-settings',
+                  );
+                }
+            ),
+          ],
           bottom: const TabBar(
             tabs: [
               Tab(icon: Icon(Icons.people,color: AppColors.buttonPrimaryGray), text: 'Students',),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import flutter_tts
 import package_info_plus
 import path_provider_foundation
 import share_plus
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
@@ -29,4 +30,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -941,6 +941,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -949,6 +973,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,9 @@ dependencies:
   csv: ^6.0.0
   share_plus: ^12.0.0
 
+  # Open About link
+  url_launcher: ^6.3.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Profile icon is shown now at the top of teacher dashboard, teacher student dashboard, and student dashboard screens. Features include current username, name, and email, along with a log out button to log the user out (no matter student or teacher) with an about link button which only directs users to the GitHub repo. Naturally, this link can be adapted to whatever help or about page we end up with later this week. 
** Note: Opening the link may require some level of permission mutations on iOS, but it works on my Android testing device. Further note that the link may not work on emulators/simulators if there isn't a path to any browser to open the link in. Flutter also seems to get confused at times on hot restarts and then attempting to open the link because it doesn't always instantiate those browser dependencies on hot restarts.