### PR TITLE
Issue with currentWordLevel not being set to a default level.

### DIFF
--- a/lib/models/current_user_model.dart
+++ b/lib/models/current_user_model.dart
@@ -178,6 +178,9 @@ class CurrentUserModel extends ChangeNotifier {
 
         if (studentProgress?.currentWordLevel != null) {
           currentWordLevel = studentProgress!.currentWordLevel;
+        } else {
+          debugPrint('CurrentUserModel: No current word level found for student ${_user!.username}, defaulting to Pre-Primer.');
+          currentWordLevel = fetchWordLevelsIncreasingDifficultyOrder().first;
         }
 
         final levelsCompleted = studentProgress?.wordLevelsCompleted;


### PR DESCRIPTION
When logging out a student and then logging back in as another student the currentWordLevel was set to null and not a default level (e.g. custom, pre-primer).